### PR TITLE
Show error line and message for traceback styles other than 'long'

### DIFF
--- a/pytest_pretty/__init__.py
+++ b/pytest_pretty/__init__.py
@@ -81,13 +81,17 @@ class CustomTerminalReporter(TerminalReporter):
             for report in fail_reports:
                 file, function_line, func = report.location
                 try:
-                    repr_entries = report.longrepr.chain[-1][0].reprentries
-                    error_line = str(repr_entries[0].reprfileloc.lineno)
-                    error = repr_entries[-1].reprfileloc.message
+                    if report.longrepr.reprtraceback.style == 'long':
+                        repr_entries = report.longrepr.chain[-1][0].reprentries
+                        error_line = str(repr_entries[0].reprfileloc.lineno)
+                        error = repr_entries[-1].reprfileloc.message
+                    else:
+                        error_line = str(report.longrepr.reprcrash.lineno)
+                        error = report.longrepr.reprcrash.message
+                    
                 except AttributeError:
                     error_line = ''
                     error = ''
-
                 table.add_row(
                     escape(file),
                     escape(func),

--- a/pytest_pretty/__init__.py
+++ b/pytest_pretty/__init__.py
@@ -88,6 +88,11 @@ class CustomTerminalReporter(TerminalReporter):
                     else:
                         error_line = str(report.longrepr.reprcrash.lineno)
                         error = report.longrepr.reprcrash.message
+                        if error.startswith('assert'):
+                            error = 'AssertionError'
+                        else:
+                            fq_error = error.split(':')[0]
+                            error = fq_error.split('.')[-1]
 
                 except AttributeError:
                     error_line = ''

--- a/pytest_pretty/__init__.py
+++ b/pytest_pretty/__init__.py
@@ -88,7 +88,7 @@ class CustomTerminalReporter(TerminalReporter):
                     else:
                         error_line = str(report.longrepr.reprcrash.lineno)
                         error = report.longrepr.reprcrash.message
-                    
+
                 except AttributeError:
                     error_line = ''
                     error = ''

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -7,7 +7,10 @@ import pytest
 def test_add():
     assert 1 + 2 == 3
 
+def test_add_fail():
+    assert 1 + 2 == 4
 
+    
 @pytest.mark.xfail(reason='This test is expected to fail')
 def test_subtract():
     assert 2 - 1 == 0
@@ -23,11 +26,29 @@ def test_base(pytester):
     pytester.makepyfile(test_str)
     result = pytester.runpytest()
     assert any('passed' in x and '1' in x for x in result.outlines)
+    assert any('failed' in x and '1' in x for x in result.outlines)
     assert any('skipped' in x and '1' in x for x in result.outlines)
     assert any('xfailed' in x and '1' in x for x in result.outlines)
-
 
 def test_fixture(pytester_pretty):
     pytester_pretty.makepyfile(test_str)
     result = pytester_pretty.runpytest()
-    result.assert_outcomes(passed=1, skipped=1, xfailed=1)
+    result.assert_outcomes(passed=1, failed=1, skipped=1, xfailed=1)
+    lines = result.outlines
+    # Look for the table row with function name, function line, and error line
+    assert any('test_add_fail' in line and '6' in line and '7' in line and "AssertionError" in line for line in lines)
+
+def test_fixture_short(pytester_pretty):
+    pytester_pretty.makepyfile(test_str)
+    result = pytester_pretty.runpytest("--tb=short")
+    result.assert_outcomes(passed=1, failed=1, skipped=1, xfailed=1)
+    lines = result.outlines
+    assert any('test_add_fail' in line and '6' in line and '7' in line and "assert (1 + 2) == 4" in line for line in lines)
+
+def test_fixture_line(pytester_pretty):
+    pytester_pretty.makepyfile(test_str)
+    result = pytester_pretty.runpytest("--tb=line")
+    result.assert_outcomes(passed=1, failed=1, skipped=1, xfailed=1)
+    lines = result.outlines
+    assert any('test_add_fail' in line and '6' in line and '7' in line and "assert (1 + 2) == 4" in line for line in lines)
+

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -30,25 +30,31 @@ def test_base(pytester):
     assert any('skipped' in x and '1' in x for x in result.outlines)
     assert any('xfailed' in x and '1' in x for x in result.outlines)
 
+
 def test_fixture(pytester_pretty):
     pytester_pretty.makepyfile(test_str)
     result = pytester_pretty.runpytest()
     result.assert_outcomes(passed=1, failed=1, skipped=1, xfailed=1)
     lines = result.outlines
     # Look for the table row with function name, function line, and error line
-    assert any('test_add_fail' in line and '6' in line and '7' in line and "AssertionError" in line for line in lines)
+    assert any('test_add_fail' in line and '6' in line and '7' in line and 'AssertionError' in line for line in lines)
+
 
 def test_fixture_short(pytester_pretty):
     pytester_pretty.makepyfile(test_str)
-    result = pytester_pretty.runpytest("--tb=short")
+    result = pytester_pretty.runpytest('--tb=short')
     result.assert_outcomes(passed=1, failed=1, skipped=1, xfailed=1)
     lines = result.outlines
-    assert any('test_add_fail' in line and '6' in line and '7' in line and "assert (1 + 2) == 4" in line for line in lines)
+    assert any(
+        'test_add_fail' in line and '6' in line and '7' in line and 'assert (1 + 2) == 4' in line for line in lines
+    )
+
 
 def test_fixture_line(pytester_pretty):
     pytester_pretty.makepyfile(test_str)
-    result = pytester_pretty.runpytest("--tb=line")
+    result = pytester_pretty.runpytest('--tb=line')
     result.assert_outcomes(passed=1, failed=1, skipped=1, xfailed=1)
     lines = result.outlines
-    assert any('test_add_fail' in line and '6' in line and '7' in line and "assert (1 + 2) == 4" in line for line in lines)
-
+    assert any(
+        'test_add_fail' in line and '6' in line and '7' in line and 'assert (1 + 2) == 4' in line for line in lines
+    )

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -10,11 +10,9 @@ def test_add():
 def test_add_fail():
     assert 1 + 2 == 4
 
-    
 @pytest.mark.xfail(reason='This test is expected to fail')
 def test_subtract():
     assert 2 - 1 == 0
-
 
 @pytest.mark.skipif(True, reason='This test is skipped')
 def test_multiply():
@@ -45,9 +43,7 @@ def test_fixture_short(pytester_pretty):
     result = pytester_pretty.runpytest('--tb=short')
     result.assert_outcomes(passed=1, failed=1, skipped=1, xfailed=1)
     lines = result.outlines
-    assert any(
-        'test_add_fail' in line and '6' in line and '7' in line and 'assert (1 + 2) == 4' in line for line in lines
-    )
+    assert any('test_add_fail' in line and '6' in line and '7' in line and 'AssertionError' in line for line in lines)
 
 
 def test_fixture_line(pytester_pretty):
@@ -55,6 +51,4 @@ def test_fixture_line(pytester_pretty):
     result = pytester_pretty.runpytest('--tb=line')
     result.assert_outcomes(passed=1, failed=1, skipped=1, xfailed=1)
     lines = result.outlines
-    assert any(
-        'test_add_fail' in line and '6' in line and '7' in line and 'assert (1 + 2) == 4' in line for line in lines
-    )
+    assert any('test_add_fail' in line and '6' in line and '7' in line and 'AssertionError' in line for line in lines)


### PR DESCRIPTION
Currently, when running with `--tb=short` or `--tb=line`, error and error line are empty.
This change adds values for these, trying to emulate the `--tb=long` behavior as closely as possible. I've run a number of error scenarios, but I didnt capture everything and it is possible that some errors don't follow the "{ExceptionName}:" pattern (as assert does for instance).
The error line may also be wrong since we only get the last entry in the stack trace.
i.e.
```
┏━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃  File                   ┃  Function         ┃  Function Line  ┃  Error Line  ┃  Error      ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│  tests/test_example.py  │  test_http_error  │  31             │  1026        │  HTTPError  │
└─────────────────────────┴───────────────────┴─────────────────┴──────────────┴─────────────┘
```
Here the error line is actually pointing to `requests.model`.